### PR TITLE
README: fix typo in JSON output example, replace `-j` with `-o`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The `--location` should be a string with your city and country code, e.g. `Londo
 
 ### JSON
 
-    $ outside -j json | jq
+    $ outside -o json | jq
     {
       "city": "Edmonton",
       "country": "CA",


### PR DESCRIPTION
_JSON_ output example in  _README_:

```shell

outside -j json

error: unexpected argument '-j' found

Usage: outside [OPTIONS]

For more information, try '--help'
```

Replace `-j` with `-o`:

```shell
outside -o json | jq -r .country
AR
```
